### PR TITLE
npm test removed

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,4 +28,3 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm run build --if-present
-    - run: npm test


### PR DESCRIPTION
Every time the GitHub action runs the project it ends up with an error because we have not assigned any tests. Therefore, it is best to remove it from the .ymal file.